### PR TITLE
requestSignTransactions demo

### DIFF
--- a/src/near/transactions.ts
+++ b/src/near/transactions.ts
@@ -1,0 +1,172 @@
+import { Action, functionCall, createTransaction } from "near-api-js/lib/transaction";
+import { NearAmount, NearGas } from "../primitives";
+import { baseDecode } from "borsh";
+import { PublicKey } from "near-api-js/lib/utils";
+import { GlobalVars } from "../stores/global";
+
+let wallet = GlobalVars.global_wallet;
+console.log("wallet in transaction", wallet)
+
+type AccountId = string;
+
+export interface NearTransactionInfo {
+	receiverId: string;
+	actions: Action[];
+}
+
+export class NearTransaction {
+	private transaction_infos: NearTransactionInfo[] = [];
+
+	constructor() {
+	}
+
+	private async createTransaction({
+		receiverId,
+		actions,
+		nonceOffset = 1,
+	}: {
+		receiverId: string;
+		actions: Action[];
+		nonceOffset?: number;
+	}) {
+		let account = wallet.account();
+		let localKey = await account.connection.signer.getPublicKey(
+			account.accountId, account.connection.networkId);
+		let accessKey = await account.accessKeyForTransaction(receiverId, actions, localKey);
+		if (!accessKey) {
+			throw new Error(
+				`Cannot find matching key for transaction sent to ${receiverId}`
+			);
+		}
+
+		const block = await account.connection.provider.block({ finality: "final" });
+		const blockHash = baseDecode(block.header.hash);
+
+		const publicKey = PublicKey.from(accessKey.public_key);
+		const nonce = accessKey.access_key.nonce + nonceOffset
+
+		return createTransaction(
+			account.accountId,
+			publicKey,
+			receiverId,
+			nonce,
+			actions,
+			blockHash
+		);
+	}
+
+	public add_action(receiver_id: AccountId, action_factory: NearActionFactory) {
+		this.transaction_infos.push({ receiverId: receiver_id, actions: [action_factory.action] })
+	}
+
+	public add_actions(receiver_id: AccountId, action_factory: NearActionFactory[]) {
+		this.transaction_infos.push({ receiverId: receiver_id, actions: action_factory.map(e => e.action) })
+	}
+
+	public add_transaction(transaction: NearTransactionFactory): NearTransaction {
+		transaction.transactionInfos.forEach(e => this.transaction_infos.push(e))
+		return this;
+	}
+
+	public async execute(callback_url?: string): Promise<void> {
+		let transactions = await Promise.all(
+			this.transaction_infos.map((ts) =>
+				this.createTransaction({
+					actions: ts.actions,
+					receiverId: ts.receiverId,
+				})
+			)
+		);
+
+		return wallet.requestSignTransactions({ transactions: transactions, callbackUrl: callback_url })
+	}
+
+}
+
+
+export interface FTStorageBalance {
+	total: string;
+	available: string;
+}
+export function ftGetStorageBalance(
+	tokenId: AccountId,
+	accountId: AccountId = wallet.getAccountId()): Promise<FTStorageBalance | null> {
+	return wallet.account().viewFunction(
+		tokenId,
+		"storage_balance_of",
+		{ account_id: accountId }
+	)
+}
+
+export class NearTransactionFactory {
+	private readonly _transactionInfos: NearTransactionInfo[];
+	public get transactionInfos() { return this._transactionInfos }
+	constructor(transactionInfos: NearTransactionInfo[]) {
+		this._transactionInfos = transactionInfos
+	}
+
+	public static async appchain_reward_claim_transactions(
+		token_id: AccountId,
+		anchor_contract_id: AccountId,
+		validator_id: AccountId,
+		delegator_id: AccountId | null = null,
+	): Promise<NearTransactionFactory> {
+
+		let depositBalance = await ftGetStorageBalance(token_id)
+
+		let transactionInfos: NearTransactionInfo[] = [];
+		if (!depositBalance || depositBalance.total === "0") {
+			transactionInfos.push({
+				receiverId: token_id,
+				actions: [NearActionFactory.ft_storage_deposit_action().action]
+			})
+		}
+		transactionInfos.push({
+			receiverId: anchor_contract_id,
+			actions: [NearActionFactory.withdraw_rewards_action(validator_id, delegator_id).action]
+		})
+		return new NearTransactionFactory(transactionInfos);
+	}
+}
+
+export class NearActionFactory {
+	private readonly _action: Action;
+	public get action() {
+		return this._action
+	}
+
+	constructor(action: Action) {
+		this._action = action
+	}
+
+	public static withdraw_rewards_action(
+		validator_id: AccountId,
+		delegator_id: AccountId | null
+	): NearActionFactory {
+		return new NearActionFactory(
+			functionCall(
+				delegator_id?"withdraw_delegator_rewards":"withdraw_validator_rewards",
+				delegator_id?
+				{delegator_id: delegator_id,validator_id: validator_id}:
+				{validator_id: validator_id},
+				NearGas.WITHDRAW_DELEGATOR_REWARDS_GAS,
+				NearAmount.NONE_NEAR
+			)
+		)
+	}
+
+	public static ft_storage_deposit_action(
+		account_id: AccountId = wallet.getAccountId(),
+		registrationOnly = false
+	): NearActionFactory {
+		return new NearActionFactory(functionCall(
+			"storage_deposit",
+			{
+				account_id: account_id,
+				registration_only: registrationOnly,
+			},
+			NearGas.FT_STORAGE_DEPOSIT_GAS,
+			NearAmount.FT_DEPOSIT_AMOUNT
+		));
+	}
+}

--- a/src/primitives.ts
+++ b/src/primitives.ts
@@ -1,4 +1,6 @@
 import Decimal from 'decimal.js';
+import BN from "bn.js";
+import {utils} from "near-api-js";
 
 export const T_GAS: Decimal = new Decimal(10 ** 12);
 export const SIMPLE_CALL_GAS = T_GAS.mul(50).toString();
@@ -9,3 +11,35 @@ export const FAILED_TO_REDIRECT_MESSAGE = 'Failed to redirect to sign transactio
 export const OCT_TOKEN_DECIMALS = 18;
 
 export const EPOCH_DURATION_MS = 24 * 3600 * 1000;
+
+export class NearGas {
+	//TGas as unit,
+	// 1TGas = 1e12gas = 0.0001 Ⓝ in 2021/12/3,
+	// 1TGas ≈ 1 millisecond of "compute" time
+	public static ONE_TERA_GAS = "1000000000000";
+	public static MAX_GAS = NearGas.TGas();
+	public static FT_STORAGE_DEPOSIT_GAS = NearGas.TGas(20);
+	public static WITHDRAW_DELEGATOR_REWARDS_GAS = NearGas.TGas(150);
+  
+	public static TGas(amount_of_tgas: number = 300): BN {
+	  return new BN(this.ONE_TERA_GAS).muln(amount_of_tgas);
+	}
+  }
+  
+  
+  export class NearAmount {
+	public static ONE_YOCTO_NEAR_RAW: string = "0.000000000000000000000001";
+	public static NONE_NEAR = NearAmount.yocto_near_amount(0) ;
+	public static ONE_YOCTO_NEAR = NearAmount.yocto_near_amount();
+	public static FT_DEPOSIT_AMOUNT = NearAmount.near_amount(0.1);
+  
+	public static yocto_near_amount(amount_of_yocto: number = 1): BN {
+	  return new BN(utils.format.parseNearAmount(this.ONE_YOCTO_NEAR_RAW)!).muln(
+		amount_of_yocto
+	  );
+	}
+  
+	public static near_amount(amount_of_near: number = 1): BN {
+	  return new BN(utils.format.parseNearAmount("1")!).muln(amount_of_near);
+	}
+  } 

--- a/src/stores/global.ts
+++ b/src/stores/global.ts
@@ -32,3 +32,7 @@ export const useGlobalStore = create((set: any): GlobalStore => ({
     set({ global });
   }
 }));
+
+export class GlobalVars {
+  public static global_wallet: WalletConnection;
+}

--- a/src/views/Appchain/RewardsModal.tsx
+++ b/src/views/Appchain/RewardsModal.tsx
@@ -36,6 +36,7 @@ import {
   FAILED_TO_REDIRECT_MESSAGE,
   COMPLEX_CALL_GAS
 } from 'primitives';
+import { NearTransaction, NearTransactionFactory } from 'near/transactions';
 
 type RewardsModalProps = {
   rewards: RewardHistory[] | undefined;
@@ -47,14 +48,14 @@ type RewardsModalProps = {
   onClose: () => void;
 }
 
-export const RewardsModal: React.FC<RewardsModalProps> = ({ 
-  isOpen, 
-  onClose, 
-  rewards, 
-  appchain, 
-  anchor, 
-  wrappedAppchainToken, 
-  validatorId 
+export const RewardsModal: React.FC<RewardsModalProps> = ({
+  isOpen,
+  onClose,
+  rewards,
+  appchain,
+  anchor,
+  wrappedAppchainToken,
+  validatorId
 }) => {
 
   const bg = useColorModeValue('#f6f7fa', '#15172c');
@@ -110,34 +111,53 @@ export const RewardsModal: React.FC<RewardsModalProps> = ({
       return;
     }
 
-    if (wrappedAppchainTokenStorageBalance.lte(ZERO_DECIMAL)) {
-      setNeedDepositStorage.on();
-      return;
-    }
-    setIsClaiming.on();
+    // if (wrappedAppchainTokenStorageBalance.lte(ZERO_DECIMAL)) {
+    //   setNeedDepositStorage.on();
+    //   return;
+    // }
+    // setIsClaiming.on();
 
-    const method = validatorId ? anchor.withdraw_delegator_rewards : anchor.withdraw_validator_rewards;
+    // const method = validatorId ? anchor.withdraw_delegator_rewards : anchor.withdraw_validator_rewards;
 
-    const params: any = validatorId ? {
-      validator_id: validatorId,
-      delegator_id: global.accountId || ''
-    } : { validator_id: global.accountId };
+    // const params: any = validatorId ? {
+    //   validator_id: validatorId,
+    //   delegator_id: global.accountId || ''
+    // } : { validator_id: global.accountId };
 
-    method(
-      params,
-      COMPLEX_CALL_GAS
-    ).catch(err => {
-      if (err.message === FAILED_TO_REDIRECT_MESSAGE) {
-        return;
-      }
+    // method(
+    //   params,
+    //   COMPLEX_CALL_GAS
+    // ).catch(err => {
+    //   if (err.message === FAILED_TO_REDIRECT_MESSAGE) {
+    //     return;
+    //   }
 
-      toast({
-        position: 'top-right',
-        title: 'Error',
-        description: err.toString(),
-        status: 'error'
-      });
-    })
+    //   toast({
+    //     position: 'top-right',
+    //     title: 'Error',
+    //     description: err.toString(),
+    //     status: 'error'
+    //   });
+    // })
+    NearTransactionFactory
+      .appchain_reward_claim_transactions(
+        wrappedAppchainToken!.contractId,
+        anchor.contractId,
+        validatorId ? validatorId : global.accountId,
+        validatorId ? global.accountId : null,
+      ).then(e => new NearTransaction().add_transaction(e).execute())
+      .catch(err => {
+        if (err.message === FAILED_TO_REDIRECT_MESSAGE) {
+          return;
+        }
+
+        toast({
+          position: 'top-right',
+          title: 'Error',
+          description: err.toString(),
+          status: 'error'
+        });
+      })
   }
 
   const onDepositStorage = () => {

--- a/src/views/Root.tsx
+++ b/src/views/Root.tsx
@@ -33,7 +33,7 @@ import {
 import { Outlet } from 'react-router-dom';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useMatchMutate } from 'hooks';
-import { useGlobalStore, useTxnsStore } from 'stores';
+import { GlobalVars, useGlobalStore, useTxnsStore } from 'stores';
 
 import { API_HOST } from 'config';
 
@@ -79,6 +79,7 @@ export const Root: React.FC = () => {
       });
   
       const wallet = new WalletConnection(near, network.octopus.registryContractId);
+      GlobalVars.global_wallet = wallet;
   
       const registry = new RegistryContract(
         wallet.account(),


### PR DESCRIPTION
# add class NearTransaction

- I  try to hidden complexity when we use requestSignTransactions in near-api-js and make it more reusable by defining class NearTransaction.
- Here is a example when I use NearTransaction to complete a transactions call:

  ```typescript
  new NearTransaction()
  .add_transaction(NearTransactionFactory.xxx())
  .execute()
  ```

# add global WalletConnection

- I need a global `WalletConnection` so I define a class GlobalVars which has a static field:

  ```typescript
  export class GlobalVars {
    public static global_wallet: WalletConnection;
  } 
  ```
- the field `global_wallet` are assigned in `src/views/Root.tsx`


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201925731349412